### PR TITLE
feat: 인증 필터 추가로 헤더에서 유저 id 받아오기 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-
+    implementation 'org.springframework.boot:spring-boot-starter-security'
     // swagger
     // 기존 2.2.0 버전은 Spring Boot 3.4.x 버전에서 Controller Handler 호환성 문제가 있어 최신 버전으로 맞춘다.
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5'

--- a/src/main/java/org/bob/siungongsi/config/SecurityConfig.java
+++ b/src/main/java/org/bob/siungongsi/config/SecurityConfig.java
@@ -5,6 +5,7 @@ import org.bob.siungongsi.service.KakaoAuthService;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
@@ -23,11 +24,17 @@ public class SecurityConfig {
     KakaoAuthFilter kakaoAuthFilter =
         new KakaoAuthFilter(kakaoAuthService); // 의존성 주입된 kakaoAuthService 사용
 
+    http.authorizeHttpRequests(
+        (authorizeRequests) -> {
+          authorizeRequests.anyRequest().permitAll();
+        });
+
+    http.csrf(AbstractHttpConfigurer::disable);
+
     http.addFilterBefore(
         kakaoAuthFilter,
         UsernamePasswordAuthenticationFilter
             .class); // UsernamePasswordAuthenticationFilter 앞에 카카오 인증 필터를 추가
-
     return http.build();
   }
 }

--- a/src/main/java/org/bob/siungongsi/config/SecurityConfig.java
+++ b/src/main/java/org/bob/siungongsi/config/SecurityConfig.java
@@ -1,0 +1,33 @@
+package org.bob.siungongsi.config;
+
+import org.bob.siungongsi.security.KakaoAuthFilter;
+import org.bob.siungongsi.service.KakaoAuthService;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+public class SecurityConfig {
+
+  private final KakaoAuthService kakaoAuthService;
+
+  // 생성자 주입을 통해 KakaoAuthService 주입
+  public SecurityConfig(KakaoAuthService kakaoAuthService) {
+    this.kakaoAuthService = kakaoAuthService;
+  }
+
+  @Bean
+  public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    KakaoAuthFilter kakaoAuthFilter =
+        new KakaoAuthFilter(kakaoAuthService); // 의존성 주입된 kakaoAuthService 사용
+
+    http.addFilterBefore(
+        kakaoAuthFilter,
+        UsernamePasswordAuthenticationFilter
+            .class); // UsernamePasswordAuthenticationFilter 앞에 카카오 인증 필터를 추가
+
+    return http.build();
+  }
+}

--- a/src/main/java/org/bob/siungongsi/controller/AuthController.java
+++ b/src/main/java/org/bob/siungongsi/controller/AuthController.java
@@ -10,6 +10,7 @@ import org.bob.siungongsi.domain.UserEntity;
 import org.bob.siungongsi.dto.ApiResponseCode;
 import org.bob.siungongsi.dto.ApiResponseWrapper;
 import org.bob.siungongsi.service.AuthService;
+import org.bob.siungongsi.service.KakaoAuthService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -17,14 +18,17 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/v1/auth") // 회원 관련 API의 기본 경로
 public class AuthController implements AuthControllerSpec {
   private final AuthService authService;
+  private final KakaoAuthService kakaoAuthService;
 
-  public AuthController(AuthService authService) {
+  public AuthController(AuthService authService, KakaoAuthService kakaoAuthService) {
     this.authService = authService;
+    this.kakaoAuthService = kakaoAuthService;
   }
 
   @Override
   @PostMapping("/register")
-  public ResponseEntity<ApiResponseWrapper<?>> registerUser(@RequestBody AuthRequest authRequest) {
+  public ResponseEntity<ApiResponseWrapper<?>> registerUser(
+      @RequestBody AuthRequest.RegisterRequest authRequest) {
 
     String socialId = authRequest.socialId();
     String accessToken = authRequest.accessToken();
@@ -43,7 +47,7 @@ public class AuthController implements AuthControllerSpec {
   @Override
   @PostMapping("/login")
   public ResponseEntity<ApiResponseWrapper<LoginSuccessResponse>> loginUser(
-      @RequestBody AuthRequest authRequest) {
+      @RequestBody AuthRequest.LoginRequest authRequest) {
 
     String accessToken = authRequest.accessToken();
     if (accessToken == null || accessToken.isBlank()) {
@@ -51,7 +55,13 @@ public class AuthController implements AuthControllerSpec {
           .body(ApiResponseWrapper.error(ApiResponseCode.AUTH_REQUIRED_AUTHORIZATION));
     }
 
-    UserEntity user = authService.login(authRequest);
+    String socialId = kakaoAuthService.validateAccessToken(accessToken);
+    if (socialId == null) {
+      return ResponseEntity.status(401)
+          .body(ApiResponseWrapper.error(ApiResponseCode.AUTH_REQUIRED_AUTHORIZATION));
+    }
+
+    UserEntity user = authService.login(authRequest, socialId);
 
     return ResponseEntity.ok(
         ApiResponseWrapper.success(

--- a/src/main/java/org/bob/siungongsi/controller/dto/AuthRequest.java
+++ b/src/main/java/org/bob/siungongsi/controller/dto/AuthRequest.java
@@ -1,3 +1,7 @@
 package org.bob.siungongsi.controller.dto;
 
-public record AuthRequest(String accessToken, String socialId) {}
+public class AuthRequest {
+  public record RegisterRequest(String accessToken, String socialId) {}
+
+  public record LoginRequest(String accessToken) {}
+}

--- a/src/main/java/org/bob/siungongsi/controller/spec/AuthControllerSpec.java
+++ b/src/main/java/org/bob/siungongsi/controller/spec/AuthControllerSpec.java
@@ -62,7 +62,8 @@ public interface AuthControllerSpec {
                   })
             })
       })
-  ResponseEntity<ApiResponseWrapper<LoginSuccessResponse>> loginUser(AuthRequest requestDto);
+  ResponseEntity<ApiResponseWrapper<LoginSuccessResponse>> loginUser(
+      AuthRequest.LoginRequest requestDto);
 
   @Operation(
       summary = "회원가입",
@@ -121,7 +122,7 @@ public interface AuthControllerSpec {
                   })
             })
       })
-  ResponseEntity<ApiResponseWrapper<?>> registerUser(AuthRequest requestDto);
+  ResponseEntity<ApiResponseWrapper<?>> registerUser(AuthRequest.RegisterRequest requestDto);
 
   @Operation(
       summary = "약관 조회",

--- a/src/main/java/org/bob/siungongsi/domain/UserEntity.java
+++ b/src/main/java/org/bob/siungongsi/domain/UserEntity.java
@@ -16,7 +16,7 @@ public class UserEntity {
   @Column(name = "social_id", nullable = false, length = 50, unique = true)
   private String socialId;
 
-  @Column(name = "access_token", nullable = false, length = 50)
+  @Column(name = "access_token", nullable = false, length = 2048)
   private String accessToken;
 
   @Column(name = "push_token_id", length = 150)

--- a/src/main/java/org/bob/siungongsi/security/KakaoAuthFilter.java
+++ b/src/main/java/org/bob/siungongsi/security/KakaoAuthFilter.java
@@ -1,0 +1,48 @@
+package org.bob.siungongsi.security;
+
+import java.io.IOException;
+
+import org.bob.siungongsi.service.KakaoAuthService;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+public class KakaoAuthFilter extends OncePerRequestFilter {
+  private final KakaoAuthService kakaoAuthService;
+
+  public KakaoAuthFilter(KakaoAuthService kakaoAuthService) {
+    this.kakaoAuthService = kakaoAuthService;
+  }
+
+  @Override
+  protected void doFilterInternal(
+      HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+      throws ServletException, IOException {
+    String authHeader = request.getHeader("Authorization");
+
+    if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+      filterChain.doFilter(request, response); // 토큰이 없으면 그냥 필터 체인 진행
+      return;
+    }
+
+    String accessToken = authHeader.substring(7); // "Bearer "를 제거한 토큰
+
+    // 토큰 검증
+    String socialId = kakaoAuthService.validateAccessToken(accessToken);
+    if (socialId != null) {
+      // 토큰이 유효하면 인증 처리 (SecurityContext에 인증 객체 저장)
+      KakaoAuthenticationToken authenticationToken = new KakaoAuthenticationToken(socialId);
+      SecurityContextHolder.getContext().setAuthentication(authenticationToken);
+    } else {
+      response.setStatus(HttpServletResponse.SC_UNAUTHORIZED); // 유효하지 않은 토큰
+      response.getWriter().write("Invalid Access Token");
+      return;
+    }
+
+    filterChain.doFilter(request, response); // 필터 체인 계속 진행
+  }
+}

--- a/src/main/java/org/bob/siungongsi/security/KakaoAuthenticationToken.java
+++ b/src/main/java/org/bob/siungongsi/security/KakaoAuthenticationToken.java
@@ -1,0 +1,20 @@
+package org.bob.siungongsi.security;
+
+import java.util.Collections;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+public class KakaoAuthenticationToken extends UsernamePasswordAuthenticationToken {
+
+  private final String socialId;
+
+  public KakaoAuthenticationToken(String socialId) {
+    super(socialId, null, Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER")));
+    this.socialId = socialId;
+  }
+
+  public String getSocialId() {
+    return socialId;
+  }
+}

--- a/src/main/java/org/bob/siungongsi/service/AuthService.java
+++ b/src/main/java/org/bob/siungongsi/service/AuthService.java
@@ -19,7 +19,7 @@ public class AuthService {
   }
 
   // 회원가입 로직: 사용자가 처음으로 로그인 시 회원을 등록
-  public UserEntity authRequest(AuthRequest authRequest) {
+  public UserEntity authRequest(AuthRequest.RegisterRequest authRequest) {
     Optional<UserEntity> existingUser = authRepository.findBySocialId(authRequest.socialId());
 
     // 이미 존재하는 사용자가 있다면 예외 처리
@@ -35,7 +35,7 @@ public class AuthService {
   }
 
   // 로그인 로직: 이미 가입된 사용자가 로그인 시 액세스 토큰 갱신
-  public UserEntity login(AuthRequest authRequest) {
+  public UserEntity login(AuthRequest.LoginRequest authRequest, String socialId) {
     String accessToken = authRequest.accessToken();
 
     // 액세스 토큰이 없으면 예외 처리
@@ -45,7 +45,7 @@ public class AuthService {
           ApiResponseCode.AUTH_REQUIRED_AUTHORIZATION.getMessage());
     }
 
-    Optional<UserEntity> user = authRepository.findBySocialId(authRequest.socialId());
+    Optional<UserEntity> user = authRepository.findBySocialId(socialId);
 
     // 가입되지 않은 사용자의 경우 예외 처리
     if (!user.isPresent()) {

--- a/src/main/java/org/bob/siungongsi/service/KakaoAuthService.java
+++ b/src/main/java/org/bob/siungongsi/service/KakaoAuthService.java
@@ -1,7 +1,10 @@
 package org.bob.siungongsi.service;
 
 import java.util.Map;
+import java.util.Optional;
 
+import org.bob.siungongsi.domain.UserEntity;
+import org.bob.siungongsi.repository.AuthRepository;
 import org.springframework.http.*;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
@@ -10,6 +13,12 @@ import org.springframework.web.client.RestTemplate;
 public class KakaoAuthService {
 
   private final RestTemplate restTemplate = new RestTemplate();
+
+  private final AuthRepository authRepository;
+
+  public KakaoAuthService(AuthRepository authRepository) {
+    this.authRepository = authRepository;
+  }
 
   public String validateAccessToken(String accessToken) {
     String url = "https://kapi.kakao.com/v1/user/access_token_info";
@@ -42,5 +51,10 @@ public class KakaoAuthService {
     }
 
     return null; // 유효하지 않거나 예외 발생 시 null 반환
+  }
+
+  public Long getUserId(String socialId) {
+    Optional<UserEntity> user = authRepository.findBySocialId(socialId);
+    return user.map(UserEntity::getId).orElse(null);
   }
 }

--- a/src/main/java/org/bob/siungongsi/service/KakaoAuthService.java
+++ b/src/main/java/org/bob/siungongsi/service/KakaoAuthService.java
@@ -1,0 +1,46 @@
+package org.bob.siungongsi.service;
+
+import java.util.Map;
+
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+public class KakaoAuthService {
+
+  private final RestTemplate restTemplate = new RestTemplate();
+
+  public String validateAccessToken(String accessToken) {
+    String url = "https://kapi.kakao.com/v1/user/access_token_info";
+
+    HttpHeaders headers = new HttpHeaders();
+    headers.set("Authorization", "Bearer " + accessToken);
+
+    HttpEntity<String> entity = new HttpEntity<>(headers);
+
+    try {
+      ResponseEntity<Map> response = restTemplate.exchange(url, HttpMethod.GET, entity, Map.class);
+
+      if (response.getStatusCode() == HttpStatus.OK) {
+        // 응답에서 'id'와 'status' 추출
+        Map<String, Object> body = response.getBody();
+        if (body != null) {
+          Object id = body.get("id");
+          Object expiresIn = body.get("expires_in");
+
+          // id와 expires_in 값을 필요한 곳에 사용할 수 있도록 반환하거나 로그로 출력 가능
+          System.out.println("ID: " + id);
+          System.out.println("Expires In: " + expiresIn);
+
+          return id.toString(); // 원하는 데이터를 반환
+        }
+      }
+    } catch (Exception e) {
+      // 예외 처리 (유효하지 않은 토큰일 경우)
+      System.out.println("Error: " + e.getMessage());
+    }
+
+    return null; // 유효하지 않거나 예외 발생 시 null 반환
+  }
+}

--- a/src/main/java/org/bob/siungongsi/service/UserService.java
+++ b/src/main/java/org/bob/siungongsi/service/UserService.java
@@ -25,7 +25,7 @@ public class UserService {
 
     // 인증된 사용자의 socialId를 가져오기
     String socialId = (String) authentication.getPrincipal();
-    System.out.println("socialId: " + kakaoAuthService.getUserId(socialId));
+    System.out.println("userId: " + kakaoAuthService.getUserId(socialId));
     return kakaoAuthService.getUserId(socialId); // socialId로 유저 ID 조회
   }
 }

--- a/src/main/java/org/bob/siungongsi/service/UserService.java
+++ b/src/main/java/org/bob/siungongsi/service/UserService.java
@@ -1,0 +1,31 @@
+package org.bob.siungongsi.service;
+
+import org.bob.siungongsi.security.KakaoAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserService {
+
+  private final KakaoAuthService kakaoAuthService;
+
+  public UserService(KakaoAuthService kakaoAuthService) {
+    this.kakaoAuthService = kakaoAuthService;
+  }
+
+  // 인증된 유저의 ID 가져오기
+  public Long getAuthenticatedUserId() {
+    // 인증된 토큰을 가져오기
+    KakaoAuthenticationToken authentication =
+        (KakaoAuthenticationToken) SecurityContextHolder.getContext().getAuthentication();
+
+    if (authentication == null) {
+      return null; // 인증되지 않은 경우 null 반환
+    }
+
+    // 인증된 사용자의 socialId를 가져오기
+    String socialId = (String) authentication.getPrincipal();
+    System.out.println("socialId: " + kakaoAuthService.getUserId(socialId));
+    return kakaoAuthService.getUserId(socialId); // socialId로 유저 ID 조회
+  }
+}


### PR DESCRIPTION
### Description

인증 필터 추가로 헤더에서 유저 id 받아오기 가능

### Related Issues

<!--
  관련된 이슈 번호를 참고하세요.
  예: Fixes #123, Closes #456
-->
- Resolves #62

### Changes Made

<!--
  이 PR에서 변경된 사항을 설명하세요.
  코드, 문서, 설정 등 변경된 내용을 상세히 기술합니다.
-->

1. security 추가로 build.gradle 추가
2. 카카오에서 엑세스 토큰 유효한 지 검사
3. 엑세스 토큰으로 카카오id 받아오고 이를 통해 userid 추출
4. UserService.getAuthenticatedUserId()하면 userId 가져올 수 있음

### Screenshots or Video

<!--
  변경된 사항이 UI에 영향을 미치는 경우, 변경 전후의 스크린샷이나 동영상을 첨부하세요.
-->

### Testing

<!--
  변경 사항을 테스트한 방법을 설명하세요.
  테스트한 환경 (OS, 브라우저, 장치 등)과 테스트 절차를 구체적으로 기술합니다.
-->

1. 로컬 db에 연결 후 확인

### Checklist

<!--
  PR 작성 시 다음 항목들을 확인하세요.
-->

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 모든 테스트가 성공적으로 통과했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [x] 코드 스타일 가이드라인을 준수했습니다.
- [x] 코드 리뷰어를 지정했습니다.

### Additional Notes

<!--
  리뷰어가 이해하는 데 도움이 될 추가적인 참고 사항이나 정보가 있다면 여기에 작성하세요.
-->

