### PR TITLE
feat: 로그인 API에 회원여부 추가

### DIFF
--- a/src/main/java/org/bob/siungongsi/controller/AuthController.java
+++ b/src/main/java/org/bob/siungongsi/controller/AuthController.java
@@ -31,7 +31,6 @@ public class AuthController implements AuthControllerSpec {
       @RequestBody AuthRequest.RegisterRequest authRequest) {
 
     String socialId = authRequest.socialId();
-    String accessToken = authRequest.accessToken();
 
     if (socialId == null || socialId.isBlank() || socialId.length() > 100) {
       return ResponseEntity.status(401)
@@ -39,6 +38,11 @@ public class AuthController implements AuthControllerSpec {
     }
 
     UserEntity user = authService.authRequest(authRequest);
+
+    if (user == null) {
+      return ResponseEntity.status(409)
+          .body(ApiResponseWrapper.error(ApiResponseCode.AUTH_USER_ALREADY_EXISTS));
+    }
 
     return ResponseEntity.status(201)
         .body(ApiResponseWrapper.success(ApiResponseCode.AUTH_REGISTER_SUCCESS));
@@ -58,7 +62,7 @@ public class AuthController implements AuthControllerSpec {
     String socialId = kakaoAuthService.validateAccessToken(accessToken);
     if (socialId == null) {
       return ResponseEntity.status(401)
-          .body(ApiResponseWrapper.error(ApiResponseCode.AUTH_REQUIRED_AUTHORIZATION));
+          .body(ApiResponseWrapper.error(ApiResponseCode.AUTH_ACCESS_TOKEN_EXPIRED));
     }
 
     boolean isUser = authService.login(authRequest, socialId) != null;

--- a/src/main/java/org/bob/siungongsi/controller/AuthController.java
+++ b/src/main/java/org/bob/siungongsi/controller/AuthController.java
@@ -61,11 +61,11 @@ public class AuthController implements AuthControllerSpec {
           .body(ApiResponseWrapper.error(ApiResponseCode.AUTH_REQUIRED_AUTHORIZATION));
     }
 
-    UserEntity user = authService.login(authRequest, socialId);
+    boolean isUser = authService.login(authRequest, socialId) != null;
 
     return ResponseEntity.ok(
         ApiResponseWrapper.success(
-            ApiResponseCode.AUTH_LOGIN_SUCCESS, LoginSuccessResponse.of(accessToken)));
+            ApiResponseCode.AUTH_LOGIN_SUCCESS, LoginSuccessResponse.of(accessToken, isUser)));
   }
 
   @Override

--- a/src/main/java/org/bob/siungongsi/controller/dto/AuthResponse.java
+++ b/src/main/java/org/bob/siungongsi/controller/dto/AuthResponse.java
@@ -6,9 +6,10 @@ public class AuthResponse {
 
   public record LoginSuccessResponse(
       @Schema(description = "JWT 액세스 토큰", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
-          String accessToken) {
-    public static LoginSuccessResponse of(String accessToken) {
-      return new LoginSuccessResponse(accessToken);
+          String accessToken,
+      boolean isUser) {
+    public static LoginSuccessResponse of(String accessToken, boolean isUser) {
+      return new LoginSuccessResponse(accessToken, isUser);
     }
   }
 }

--- a/src/main/java/org/bob/siungongsi/service/AuthService.java
+++ b/src/main/java/org/bob/siungongsi/service/AuthService.java
@@ -45,20 +45,11 @@ public class AuthService {
   public UserEntity login(AuthRequest.LoginRequest authRequest, String socialId) {
     String accessToken = authRequest.accessToken();
 
-    // 액세스 토큰이 없으면 예외 처리
-    if (accessToken == null || accessToken.isEmpty()) {
-      throw new CustomException(
-          ApiResponseCode.AUTH_REQUIRED_AUTHORIZATION,
-          ApiResponseCode.AUTH_REQUIRED_AUTHORIZATION.getMessage());
-    }
-
     Optional<UserEntity> user = userRepository.findBySocialId(socialId);
 
-    // 가입되지 않은 사용자의 경우 예외 처리
+    // 가입되지 않은 사용자의 경우
     if (!user.isPresent()) {
-      throw new CustomException(
-          ApiResponseCode.AUTH_REQUIRED_AUTHORIZATION,
-          ApiResponseCode.AUTH_REQUIRED_AUTHORIZATION.getMessage());
+      return null;
     }
 
     // 기존 사용자일 경우 액세스 토큰 갱신

--- a/src/main/java/org/bob/siungongsi/service/AuthService.java
+++ b/src/main/java/org/bob/siungongsi/service/AuthService.java
@@ -31,9 +31,7 @@ public class AuthService {
 
     // 이미 존재하는 사용자가 있다면 예외 처리
     if (existingUser.isPresent()) {
-      throw new CustomException(
-          ApiResponseCode.AUTH_USER_ALREADY_EXISTS,
-          ApiResponseCode.AUTH_USER_ALREADY_EXISTS.getMessage());
+      return null;
     }
 
     // 새로운 사용자 등록

--- a/src/main/java/org/bob/siungongsi/service/KakaoAuthService.java
+++ b/src/main/java/org/bob/siungongsi/service/KakaoAuthService.java
@@ -4,6 +4,8 @@ import java.util.Map;
 import java.util.Optional;
 
 import org.bob.siungongsi.domain.UserEntity;
+import org.bob.siungongsi.dto.ApiResponseCode;
+import org.bob.siungongsi.exception.CustomException;
 import org.bob.siungongsi.repository.UserRepository;
 import org.springframework.http.*;
 import org.springframework.stereotype.Service;
@@ -32,22 +34,14 @@ public class KakaoAuthService {
       ResponseEntity<Map> response = restTemplate.exchange(url, HttpMethod.GET, entity, Map.class);
 
       if (response.getStatusCode() == HttpStatus.OK) {
-        // 응답에서 'id'와 'status' 추출
         Map<String, Object> body = response.getBody();
         if (body != null) {
-          Object id = body.get("id");
-          Object expiresIn = body.get("expires_in");
-
-          // id와 expires_in 값을 필요한 곳에 사용할 수 있도록 반환하거나 로그로 출력 가능
-          System.out.println("ID: " + id);
-          System.out.println("Expires In: " + expiresIn);
-
-          return id.toString(); // 원하는 데이터를 반환
+          return body.get("id").toString(); // 원하는 데이터를 반환
         }
       }
     } catch (Exception e) {
       // 예외 처리 (유효하지 않은 토큰일 경우)
-      System.out.println("Error: " + e.getMessage());
+      throw new CustomException(ApiResponseCode.AUTH_REQUIRED_AUTHORIZATION, "유효하지 않은 토큰입니다.");
     }
 
     return null; // 유효하지 않거나 예외 발생 시 null 반환


### PR DESCRIPTION
### Description

<!--
  간단하게 PR의 목적을 설명하세요.
  이 PR이 해결하려는 문제나 추가하려는 기능에 대해 요약해주세요.
-->
프론트에서 유저 여부 파악할 수 있게 로그인 시 회원여부 추가
회원일 시 isUser에 true 아닐 시 false

### Related Issues

<!--
  관련된 이슈 번호를 참고하세요.
  예: Fixes #123, Closes #456
-->
- Resolves #73 

### Changes Made

<!--
  이 PR에서 변경된 사항을 설명하세요.
  코드, 문서, 설정 등 변경된 내용을 상세히 기술합니다.
-->

1. 로그인 API에 응답 수정
2. isUser라는 회원여부 판단하는 응답 추가
3. 유효한 토큰이 아닐 시에는 에러 반환
4. 유효한 토큰이면서 회원이 아닐 시에는 프론트측에서 약관 동의를 받고 회원가입 API 요청
5. 필요없는 코드 삭제

### Screenshots or Video

<!--
  변경된 사항이 UI에 영향을 미치는 경우, 변경 전후의 스크린샷이나 동영상을 첨부하세요.
-->

### Testing

<!--
  변경 사항을 테스트한 방법을 설명하세요.
  테스트한 환경 (OS, 브라우저, 장치 등)과 테스트 절차를 구체적으로 기술합니다.
-->

1. 스웨거로 테스팅

### Checklist

<!--
  PR 작성 시 다음 항목들을 확인하세요.
-->

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 모든 테스트가 성공적으로 통과했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [x] 코드 스타일 가이드라인을 준수했습니다.
- [x] 코드 리뷰어를 지정했습니다.

### Additional Notes

<!--
  리뷰어가 이해하는 데 도움이 될 추가적인 참고 사항이나 정보가 있다면 여기에 작성하세요.
-->

스웨거 토큰 넣을 때 Bearer 포함할 필요 없었음 
엑세스 토큰만 포함하면 정상 작동되는 거 확인 