### PR TITLE
feat: 공시상세조회 API 개발

### DIFF
--- a/src/main/java/org/bob/siungongsi/client/clientinterface/KoreanInvestmentClient.java
+++ b/src/main/java/org/bob/siungongsi/client/clientinterface/KoreanInvestmentClient.java
@@ -1,0 +1,82 @@
+package org.bob.siungongsi.client.clientinterface;
+
+import org.bob.siungongsi.service.KoreanInvestmentTokenManager;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@Component
+public class KoreanInvestmentClient {
+
+  private final ObjectMapper objectMapper;
+  private final RestTemplate restTemplate;
+  private final KoreanInvestmentTokenManager tokenManager;
+
+  @Value("${korean.investment.appkey}")
+  private String appKey;
+
+  @Value("${korean.investment.secretkey}")
+  private String secretKey;
+
+  @Value("${korean.investment.stock.url}")
+  private String stockUrl;
+
+  public KoreanInvestmentClient(
+      ObjectMapper objectMapper, KoreanInvestmentTokenManager tokenManager) {
+    this.objectMapper = objectMapper;
+    this.tokenManager = tokenManager;
+    this.restTemplate = new RestTemplate();
+  }
+
+  public double getPrdyCtr(String stockCode) {
+    try {
+      String accessToken = tokenManager.getAccessToken();
+      return fetchStockData(accessToken, stockCode);
+    } catch (Exception e) {
+      System.err.println("Error fetching prdyCtr from Korean Investment API: " + e.getMessage());
+      throw new RuntimeException("Failed to fetch prdyCtr: " + e.getMessage());
+    }
+  }
+
+  private double fetchStockData(String accessToken, String stockCode) {
+    try {
+      HttpHeaders headers = new HttpHeaders();
+      headers.setContentType(MediaType.APPLICATION_JSON);
+      headers.set("authorization", "Bearer " + accessToken);
+      headers.set("appkey", appKey);
+      headers.set("appsecret", secretKey);
+      headers.set("tr_id", "FHKST01010100");
+      headers.set("custtype", "P"); // 개인(P) 타입으로 설정
+
+      String url = stockUrl + "?FID_COND_MRKT_DIV_CODE=J&FID_INPUT_ISCD=" + stockCode;
+
+      HttpEntity<String> entity = new HttpEntity<>(headers);
+
+      ResponseEntity<String> response =
+          restTemplate.exchange(url, HttpMethod.GET, entity, String.class);
+
+      JsonNode root = objectMapper.readTree(response.getBody());
+
+      JsonNode outputData = root.path("output");
+      String prdyCtrt = outputData.path("prdy_ctrt").asText();
+
+      return Double.parseDouble(prdyCtrt.replaceAll("[^0-9.-]", ""));
+
+    } catch (RestClientException e) {
+      System.err.println("Error fetching stock data from Korean Investment API: " + e.getMessage());
+      throw new RuntimeException("Failed to fetch stock data: " + e.getMessage());
+    } catch (Exception e) {
+      System.err.println("Error processing stock data: " + e.getMessage());
+      throw new RuntimeException("Failed to process stock data: " + e.getMessage());
+    }
+  }
+}

--- a/src/main/java/org/bob/siungongsi/controller/GongsiController.java
+++ b/src/main/java/org/bob/siungongsi/controller/GongsiController.java
@@ -1,27 +1,37 @@
 package org.bob.siungongsi.controller;
 
+import static org.bob.siungongsi.dto.ApiResponseCode.GONGSI_DETAIL_SUCCESS;
 import static org.bob.siungongsi.dto.ApiResponseCode.GONGSI_LIST_SUCCESS;
 
-import org.bob.siungongsi.controller.dto.CompanyResponse.CompanyInfo;
+import org.bob.siungongsi.controller.dto.CompanyResponse;
 import org.bob.siungongsi.controller.dto.GongsiResponse.GongsiDetailResponse;
-import org.bob.siungongsi.controller.dto.GongsiResponse.GongsiInfo;
 import org.bob.siungongsi.controller.dto.GongsiResponse.GongsiListResponse;
 import org.bob.siungongsi.controller.spec.GongsiControllerSpec;
 import org.bob.siungongsi.dto.ApiResponseWrapper;
+import org.bob.siungongsi.repository.NotificationRepository;
 import org.bob.siungongsi.service.GongsiService;
+import org.bob.siungongsi.service.UserService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import io.swagger.v3.oas.annotations.Parameter;
+import jakarta.servlet.http.HttpServletRequest;
 
 @RestController
 @RequestMapping("/v1/gongsi") // 공시 API의 기본 경로
 public class GongsiController implements GongsiControllerSpec {
 
   private final GongsiService gongsiService;
+  private final UserService userService;
+  private final NotificationRepository notificationRepository;
 
-  public GongsiController(GongsiService gongsiService) {
+  public GongsiController(
+      GongsiService gongsiService,
+      UserService userService,
+      NotificationRepository notificationRepository) {
     this.gongsiService = gongsiService;
+    this.userService = userService;
+    this.notificationRepository = notificationRepository;
   }
 
   @Override
@@ -42,24 +52,58 @@ public class GongsiController implements GongsiControllerSpec {
   }
 
   @Override
-  @GetMapping("/{gongsild}")
+  @GetMapping("/{gongsiId}")
   public ResponseEntity<ApiResponseWrapper<GongsiDetailResponse>> getGongsiDetail(
-      @Parameter(description = "공시 ID", example = "101", required = true) @PathVariable("gongsild")
-          Long gongsild) {
+      @Parameter(description = "공시 ID", example = "101", required = true) @PathVariable("gongsiId")
+          Long gongsiId,
+      HttpServletRequest request) {
 
-    GongsiInfo gongsi =
-        GongsiInfo.of(
-            101,
-            "삼성전자, 새로운 반도체 기술 발표",
-            "25.02.25 16:04",
-            1200,
-            "삼성전자가 새로운 반도체 기술을 공개하며...",
-            "https://hellothere.xxx");
+    String ipAddress = getClientIpAddress(request);
 
-    CompanyInfo company = CompanyInfo.of(1, "삼성전자", 2.43, false);
+    boolean isSubscribed = false;
 
-    GongsiDetailResponse response = GongsiDetailResponse.of(gongsi, company);
+    try {
+      Long userId = userService.getAuthenticatedUserId();
 
-    return ResponseEntity.ok(ApiResponseWrapper.success(GONGSI_LIST_SUCCESS, response));
+      if (userId != null) {
+        Long companyId = gongsiService.getCompanyIdByGongsiId(gongsiId);
+
+        isSubscribed = notificationRepository.existsByUserIdAndCompanyId(userId, companyId);
+      }
+    } catch (Exception e) {
+    }
+
+    GongsiDetailResponse response = gongsiService.getGongsiDetail(gongsiId, ipAddress);
+
+    if (response != null) {
+      CompanyResponse.CompanyInfo companyInfo = response.company();
+      CompanyResponse.CompanyInfo updatedCompanyInfo =
+          CompanyResponse.CompanyInfo.of(
+              companyInfo.id(), companyInfo.name(), companyInfo.prdyCtr(), isSubscribed);
+
+      response = GongsiDetailResponse.of(response.gongsi(), updatedCompanyInfo);
+    }
+
+    return ResponseEntity.ok(ApiResponseWrapper.success(GONGSI_DETAIL_SUCCESS, response));
+  }
+
+  private String getClientIpAddress(HttpServletRequest request) {
+    String ipAddress = request.getHeader("X-Forwarded-For");
+    if (ipAddress == null || ipAddress.isEmpty() || "unknown".equalsIgnoreCase(ipAddress)) {
+      ipAddress = request.getHeader("Proxy-Client-IP");
+    }
+    if (ipAddress == null || ipAddress.isEmpty() || "unknown".equalsIgnoreCase(ipAddress)) {
+      ipAddress = request.getHeader("WL-Proxy-Client-IP");
+    }
+    if (ipAddress == null || ipAddress.isEmpty() || "unknown".equalsIgnoreCase(ipAddress)) {
+      ipAddress = request.getHeader("HTTP_CLIENT_IP");
+    }
+    if (ipAddress == null || ipAddress.isEmpty() || "unknown".equalsIgnoreCase(ipAddress)) {
+      ipAddress = request.getHeader("HTTP_X_FORWARDED_FOR");
+    }
+    if (ipAddress == null || ipAddress.isEmpty() || "unknown".equalsIgnoreCase(ipAddress)) {
+      ipAddress = request.getRemoteAddr();
+    }
+    return ipAddress;
   }
 }

--- a/src/main/java/org/bob/siungongsi/controller/spec/GongsiControllerSpec.java
+++ b/src/main/java/org/bob/siungongsi/controller/spec/GongsiControllerSpec.java
@@ -13,6 +13,7 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 
 @Tag(name = "공시 API", description = "공시 정보를 조회하는 API")
 public interface GongsiControllerSpec {
@@ -87,7 +88,7 @@ public interface GongsiControllerSpec {
   ResponseEntity<ApiResponseWrapper<GongsiListResponse>> getGongsiList(
       @Parameter(description = "조회 대상 회사 ID", example = "1") Long companyId,
       @Parameter(description = "정렬 기준 (latest, views, oldest)", example = "latest") String sort,
-      @Parameter(description = "내용 포함 여부", example = "false") Boolean content,
+      @Parameter(description = "내용 포함 여부", example = "false") Boolean includeContent,
       @Parameter(description = "페이지 번호 (1~100)", example = "1") Integer page,
       @Parameter(description = "페이지 크기 (10~100)", example = "8") Integer size,
       @Parameter(description = "시작 날짜 (yyyy-MM-dd)", example = "2025-03-01") String startDate,
@@ -151,5 +152,6 @@ public interface GongsiControllerSpec {
             })
       })
   ResponseEntity<ApiResponseWrapper<GongsiDetailResponse>> getGongsiDetail(
-      @Parameter(description = "공시 ID", example = "101", required = true) Long gongsild);
+      @Parameter(description = "공시 ID", example = "101", required = true) Long gongsiId,
+      HttpServletRequest request);
 }

--- a/src/main/java/org/bob/siungongsi/domain/GongsiViewHistoryEntity.java
+++ b/src/main/java/org/bob/siungongsi/domain/GongsiViewHistoryEntity.java
@@ -1,0 +1,48 @@
+package org.bob.siungongsi.domain;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "gongsi_view_histories")
+public class GongsiViewHistoryEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "id", nullable = false, updatable = false)
+  private Long id;
+
+  @Column(name = "gongsi_id", nullable = false)
+  private Long gongsiId;
+
+  @Column(name = "ip_address", nullable = false)
+  private String ipAddress;
+
+  @Column(name = "createdDt", nullable = false)
+  private LocalDateTime createdDt;
+
+  protected GongsiViewHistoryEntity() {}
+
+  public GongsiViewHistoryEntity(Long gongsiId, String ipAddress) {
+    this.gongsiId = gongsiId;
+    this.ipAddress = ipAddress;
+    this.createdDt = LocalDateTime.now();
+  }
+
+  public Long getId() {
+    return id;
+  }
+
+  public Long getGongsiId() {
+    return gongsiId;
+  }
+
+  public String getIpAddress() {
+    return ipAddress;
+  }
+
+  public LocalDateTime getCreatedDt() {
+    return createdDt;
+  }
+}

--- a/src/main/java/org/bob/siungongsi/dto/ApiResponseCode.java
+++ b/src/main/java/org/bob/siungongsi/dto/ApiResponseCode.java
@@ -3,6 +3,7 @@ package org.bob.siungongsi.dto;
 public enum ApiResponseCode {
   // 공시 관련 응답 코드 (1)
   GONGSI_LIST_SUCCESS(1200, "get_gongsi_list_success"),
+  GONGSI_DETAIL_SUCCESS(1201, "get_detail_gongsi_success"),
   GONGSI_INVALID_SORT_TYPE(1400, "invalid_sort_type"),
   GONGSI_INVALID_COMPANY_ID(1401, "invalid_company_id"),
   GONGSI_INVALID_DATE_PAIR(1402, "invalid_date_pair"),
@@ -44,6 +45,9 @@ public enum ApiResponseCode {
   NOTIFICATION_REQUIRED_STATUS(5403, "required_notification_status"),
   NOTIFICATION_NOT_FOUND(5404, "notification_not_found"),
   NOTIFICATION_INTERNAL_SERVER_ERROR(5500, "internal_server_error"),
+
+  // 외부 API 관련 응답 코드 (6)
+  EXTERNAL_API_ERROR(6400, "external_api_error"),
 
   // 처리 실패 공시 관련 응답 코드 (123)
   FAILED_GONGSI_NOT_FOUND(123400, "failed_gongsi_not_found");

--- a/src/main/java/org/bob/siungongsi/repository/GongsiViewHistoryRepository.java
+++ b/src/main/java/org/bob/siungongsi/repository/GongsiViewHistoryRepository.java
@@ -1,0 +1,15 @@
+package org.bob.siungongsi.repository;
+
+import org.bob.siungongsi.domain.GongsiViewHistoryEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface GongsiViewHistoryRepository extends JpaRepository<GongsiViewHistoryEntity, Long> {
+
+  @Query(
+      "SELECT COUNT(DISTINCT g.ipAddress) FROM GongsiViewHistoryEntity g WHERE g.gongsiId = :gongsiId")
+  int countUniqueViewsByGongsiId(@Param("gongsiId") Long gongsiId);
+
+  boolean existsByGongsiIdAndIpAddress(Long gongsiId, String ipAddress);
+}

--- a/src/main/java/org/bob/siungongsi/service/GongsiService.java
+++ b/src/main/java/org/bob/siungongsi/service/GongsiService.java
@@ -6,28 +6,72 @@ import java.time.format.DateTimeParseException;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.bob.siungongsi.client.clientinterface.KoreanInvestmentClient;
+import org.bob.siungongsi.controller.dto.CompanyResponse;
 import org.bob.siungongsi.controller.dto.GongsiResponse;
 import org.bob.siungongsi.controller.dto.PaginationResponse;
 import org.bob.siungongsi.domain.CompanyEntity;
 import org.bob.siungongsi.domain.GongsiEntity;
+import org.bob.siungongsi.domain.GongsiViewHistoryEntity;
 import org.bob.siungongsi.dto.ApiResponseCode;
 import org.bob.siungongsi.exception.CustomException;
 import org.bob.siungongsi.repository.CompanyRepository;
 import org.bob.siungongsi.repository.GongsiRepository;
+import org.bob.siungongsi.repository.GongsiViewHistoryRepository;
+import org.bob.siungongsi.repository.NotificationRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class GongsiService {
   private final GongsiRepository gongsiRepository;
   private final CompanyRepository companyRepository;
+  private final GongsiViewHistoryRepository gongsiViewHistoryRepository;
+  private final NotificationRepository notificationRepository;
+  private final KoreanInvestmentClient koreanInvestmentClient;
 
-  public GongsiService(GongsiRepository gongsiRepository, CompanyRepository companyRepository) {
+  public GongsiService(
+      GongsiRepository gongsiRepository,
+      CompanyRepository companyRepository,
+      GongsiViewHistoryRepository gongsiViewHistoryRepository,
+      NotificationRepository notificationRepository,
+      KoreanInvestmentClient koreanInvestmentClient) {
     this.gongsiRepository = gongsiRepository;
     this.companyRepository = companyRepository;
+    this.gongsiViewHistoryRepository = gongsiViewHistoryRepository;
+    this.notificationRepository = notificationRepository;
+    this.koreanInvestmentClient = koreanInvestmentClient;
+  }
+
+  private Long getCurrentUserId() {
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    if (authentication != null
+        && authentication.isAuthenticated()
+        && !"anonymousUser".equals(authentication.getPrincipal().toString())) {
+      try {
+        return Long.valueOf(authentication.getName());
+      } catch (Exception e) {
+        System.err.println("Error extracting user ID: " + e.getMessage());
+      }
+    }
+    return null; // 익명의 유저면 null 반환
+  }
+
+  public Long getCompanyIdByGongsiId(Long gongsiId) {
+    GongsiEntity gongsi =
+        gongsiRepository
+            .findById(gongsiId)
+            .orElseThrow(
+                () ->
+                    new CustomException(
+                        ApiResponseCode.GONGSI_NOT_FOUND, "Gongsi not found with ID: " + gongsiId));
+    return Long.valueOf(gongsi.getCompany().getId());
   }
 
   public GongsiResponse.GongsiListResponse getGongsiList(
@@ -99,6 +143,68 @@ public class GongsiService {
         PaginationResponse.of(page, gongsiPage.getTotalPages(), gongsiPage.getTotalElements());
 
     return GongsiResponse.GongsiListResponse.of(gongsiItems, gongsiItems.size(), pagination);
+  }
+
+  @Transactional
+  public GongsiResponse.GongsiDetailResponse getGongsiDetail(Long gongsiId, String ipAddress) {
+    GongsiEntity gongsi =
+        gongsiRepository
+            .findById(gongsiId)
+            .orElseThrow(
+                () ->
+                    new CustomException(
+                        ApiResponseCode.GONGSI_NOT_FOUND, "Gongsi not found with ID: " + gongsiId));
+
+    if (!gongsiViewHistoryRepository.existsByGongsiIdAndIpAddress(gongsiId, ipAddress)) {
+      GongsiViewHistoryEntity viewHistory = new GongsiViewHistoryEntity(gongsiId, ipAddress);
+      gongsiViewHistoryRepository.save(viewHistory);
+    }
+
+    int viewCount = gongsiViewHistoryRepository.countUniqueViewsByGongsiId(gongsiId);
+
+    String formattedDate =
+        gongsi.getCreatedDt().format(DateTimeFormatter.ofPattern("yy.MM.dd HH:mm"));
+
+    GongsiResponse.GongsiInfo gongsiInfo =
+        GongsiResponse.GongsiInfo.of(
+            gongsi.getId(),
+            gongsi.getGongsiTitle(),
+            formattedDate,
+            viewCount,
+            gongsi.getContentSummary(),
+            gongsi.getOriginalGongsiLink());
+
+    CompanyEntity company = gongsi.getCompany();
+
+    boolean isSubscribed = false;
+    try {
+      Long userId = getCurrentUserId();
+      if (userId != null) {
+        isSubscribed =
+            notificationRepository.existsByUserIdAndCompanyId(
+                userId, Long.valueOf(company.getId()));
+      }
+    } catch (Exception e) {
+      System.err.println("Error checking subscription status: " + e.getMessage());
+    }
+
+    double prdyCtr = 0.0;
+    try {
+      String stockCode = company.getStockCode();
+
+      if (stockCode != null && !stockCode.isEmpty()) {
+        prdyCtr = koreanInvestmentClient.getPrdyCtr(stockCode);
+      }
+    } catch (Exception e) {
+      System.err.println("Error fetching prdyCtr: " + e.getMessage());
+      prdyCtr = 0.0; // Default value
+    }
+
+    CompanyResponse.CompanyInfo companyInfo =
+        CompanyResponse.CompanyInfo.of(
+            company.getId(), company.getCompanyName(), prdyCtr, isSubscribed);
+
+    return GongsiResponse.GongsiDetailResponse.of(gongsiInfo, companyInfo);
   }
 
   private GongsiResponse.GongsiItem mapToGongsiItem(GongsiEntity entity, boolean includeContent) {

--- a/src/main/java/org/bob/siungongsi/service/KoreanInvestmentTokenManager.java
+++ b/src/main/java/org/bob/siungongsi/service/KoreanInvestmentTokenManager.java
@@ -1,0 +1,111 @@
+package org.bob.siungongsi.service;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.annotation.PostConstruct;
+
+@Service
+public class KoreanInvestmentTokenManager {
+
+  private final RestTemplate restTemplate;
+  private final ObjectMapper objectMapper;
+
+  @Value("${korean.investment.appkey}")
+  private String appKey;
+
+  @Value("${korean.investment.secretkey}")
+  private String secretKey;
+
+  @Value("${korean.investment.token.url}")
+  private String tokenUrl;
+
+  private String accessToken;
+
+  public KoreanInvestmentTokenManager(ObjectMapper objectMapper) {
+    this.objectMapper = objectMapper;
+    this.restTemplate = new RestTemplate();
+  }
+
+  @PostConstruct
+  public void init() {
+    refreshAccessToken();
+  }
+
+  @Scheduled(cron = "0 0 0 * * *")
+  public void scheduledTokenRefresh() {
+    refreshAccessToken();
+  }
+
+  public void refreshAccessToken() {
+    try {
+      Map<String, String> requestBody = new HashMap<>();
+      requestBody.put("grant_type", "client_credentials");
+      requestBody.put("appkey", appKey);
+      requestBody.put("appsecret", secretKey);
+
+      HttpHeaders headers = new HttpHeaders();
+      headers.setContentType(MediaType.APPLICATION_JSON);
+
+      HttpEntity<Map<String, String>> entity = new HttpEntity<>(requestBody, headers);
+
+      ResponseEntity<String> response =
+          restTemplate.exchange(tokenUrl, HttpMethod.POST, entity, String.class);
+
+      String responseBody = response.getBody();
+      JsonNode root = objectMapper.readTree(responseBody);
+
+      if (root.has("error_code")) {
+        throw new Exception(
+            "API Error: "
+                + root.path("error_code").asText()
+                + " - "
+                + root.path("error_description").asText());
+      }
+
+      String approvalKey = null;
+      if (root.has("approval_key")) {
+        approvalKey = root.path("approval_key").asText();
+      } else if (root.has("access_token")) {
+        approvalKey = root.path("access_token").asText();
+      } else if (root.has("token")) {
+        approvalKey = root.path("token").asText();
+      }
+
+      if (approvalKey == null || approvalKey.isEmpty()) {
+        System.out.println("Available fields in response: ");
+        root.fieldNames().forEachRemaining(fieldName -> System.out.println(" - " + fieldName));
+        throw new Exception(
+            "Failed to get approval key. Response fields don't match expected format.");
+      }
+      accessToken = approvalKey;
+    } catch (Exception e) {
+      System.err.println("Error refreshing Korean Investment API token: " + e.getMessage());
+
+      if (accessToken == null) {
+        throw new RuntimeException(
+            "Failed to initialize access token. Please check your API credentials.");
+      }
+    }
+  }
+
+  public String getAccessToken() {
+    if (accessToken == null) {
+      refreshAccessToken();
+    }
+    return accessToken;
+  }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -51,7 +51,6 @@ sqs:
   listener:
     enabled: false
 
-
 opendart:
   api:
     key: "dummy"
@@ -61,3 +60,12 @@ opendart:
 google-ai:
   api:
     key: "dummy"
+
+korean:
+  investment:
+    appkey: ${KOREAN_INVESTMENT_APPKEY}
+    secretkey: ${KOREAN_INVESTMENT_SECRETKEY}
+    token:
+      url: https://openapi.koreainvestment.com:9443/oauth2/tokenP
+    stock:
+      url: https://openapi.koreainvestment.com:9443/uapi/domestic-stock/v1/quotations/inquire-price


### PR DESCRIPTION
### Description

알림 허용 상태 변경 API, 알림 허용 여부 확인 API 개발 끝났습니다

### Related Issues

<!--
  관련된 이슈 번호를 참고하세요.
  예: Fixes #123, Closes #456
-->
- Resolves #19 

### Changes Made

1. 주가 정보를 한국투자증권 API를 통해서 가져와야한다.
    해당 과정에서 approval_key가 필요한데 이 부분 또한 한국투자증권의 실시간 (웹소켓) 접속키 발급[실시간-000] API를 통해서 받아온 후 그 키를 다시 사용해서 정보를 받아온다. approval_key의 경우 매일 0시에 다시 받아오는 스케쥴러가 추가됐다.
3. 접속자의 IP를 이용해서 조회수를 증가시키는 로직을 추가했다.
4. 회원이 로그인을 했다면 구독을 하는 중인지 아닌지 확인을 하는 작업이 추가됐다

### Testing

정상적으로 토큰 값과 정보를 받아오는 것을 확인했습니다.

### Checklist

<!--
  PR 작성 시 다음 항목들을 확인하세요.
-->

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 모든 테스트가 성공적으로 통과했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [x] 코드 스타일 가이드라인을 준수했습니다.
- [x] 코드 리뷰어를 지정했습니다.

### Additional Notes

<!--
  리뷰어가 이해하는 데 도움이 될 추가적인 참고 사항이나 정보가 있다면 여기에 작성하세요.
-->
https://apiportal.koreainvestment.com/apiservice/oauth2#L_fa778c98-f68d-451e-8fff-b1c6bfe5cd30
https://apiportal.koreainvestment.com/apiservice/apiservice-domestic-stock-quotations2#L_07802512-4f49-4486-91b4-1050b6f5dc9d