### PR TITLE
fix: 공시 목록 조회 날짜 필터링 불가 해결

### DIFF
--- a/src/main/java/org/bob/siungongsi/repository/GongsiRepository.java
+++ b/src/main/java/org/bob/siungongsi/repository/GongsiRepository.java
@@ -19,8 +19,8 @@ public interface GongsiRepository extends JpaRepository<GongsiEntity, Long> {
 
   @Query(
       "SELECT g FROM GongsiEntity g WHERE g.company = :company "
-          + "AND (:startDate IS NULL OR g.createdDt >= :startDate) "
-          + "AND (:endDate IS NULL OR g.createdDt <= :endDate)")
+          + "AND (:startDate IS NULL OR DATE(g.createdDt) >= :startDate) "
+          + "AND (:endDate IS NULL OR DATE(g.createdDt) <= :endDate)")
   Page<GongsiEntity> findByCompanyAndDateRange(
       @Param("company") CompanyEntity company,
       @Param("startDate") LocalDate startDate,
@@ -29,8 +29,8 @@ public interface GongsiRepository extends JpaRepository<GongsiEntity, Long> {
 
   @Query(
       "SELECT g FROM GongsiEntity g WHERE "
-          + "(:startDate IS NULL OR g.createdDt >= :startDate) "
-          + "AND (:endDate IS NULL OR g.createdDt <= :endDate)")
+          + "(:startDate IS NULL OR DATE(g.createdDt) >= :startDate) "
+          + "AND (:endDate IS NULL OR DATE(g.createdDt) <= :endDate)")
   Page<GongsiEntity> findByDateRange(
       @Param("startDate") LocalDate startDate,
       @Param("endDate") LocalDate endDate,


### PR DESCRIPTION
### Description

<!--
  간단하게 PR의 목적을 설명하세요.
  이 PR이 해결하려는 문제나 추가하려는 기능에 대해 요약해주세요.
-->
공시 목록 조회에 최신순, 오랜된순이 날짜 필터링이 안되었던 이슈가 있었는데 해결했습니다.

### Related Issues

<!--
  관련된 이슈 번호를 참고하세요.
  예: Fixes #123, Closes #456
-->
- Resolves #89 

### Changes Made

<!--
  이 PR에서 변경된 사항을 설명하세요.
  코드, 문서, 설정 등 변경된 내용을 상세히 기술합니다.
-->
문제는 GongsiService.java에서 날짜 필터링 시 parsedStartDate와 parsedEndDate 매개변수를 사용할 때의 타입 불일치였습니다.
LocalDate 타입과 LocalDateTime 타입의 비교가 제대로 작동하지 않았습니다.
그래서 해당 부분을 DATE 타입으로 바꿔주었습니다
`"(:startDate IS NULL OR DATE(g.createdDt) >= :startDate) "`
`"AND (:endDate IS NULL OR DATE(g.createdDt) <= :endDate)"`

### Screenshots or Video

<!--
  변경된 사항이 UI에 영향을 미치는 경우, 변경 전후의 스크린샷이나 동영상을 첨부하세요.
-->

### Testing

<!--
  변경 사항을 테스트한 방법을 설명하세요.
  테스트한 환경 (OS, 브라우저, 장치 등)과 테스트 절차를 구체적으로 기술합니다.
-->

스웨거 허브에서 정상 작동하는 것을 확인했습니다

### Checklist

<!--
  PR 작성 시 다음 항목들을 확인하세요.
-->

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 모든 테스트가 성공적으로 통과했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [x] 코드 스타일 가이드라인을 준수했습니다.
- [x] 코드 리뷰어를 지정했습니다.

### Additional Notes

<!--
  리뷰어가 이해하는 데 도움이 될 추가적인 참고 사항이나 정보가 있다면 여기에 작성하세요.
-->

