### PR TITLE
개발 편의 API 분리 (기존 AdminController 분리)

### DIFF
--- a/src/main/java/org/bob/siungongsi/api/controller/DevSupportController.java
+++ b/src/main/java/org/bob/siungongsi/api/controller/DevSupportController.java
@@ -35,9 +35,18 @@ public class DevSupportController implements DevSupportControllerSpec {
 
   @PostMapping("/token")
   @Override
-  public ResponseEntity<ApiResponseWrapper<?>> getToken(@RequestParam("userId") String userId) {
-    ApiResponseWrapper<?> response =
-        new ApiResponseWrapper<>(12341243, "토큰 획득", jwtProvider.createJwtToken(userId));
+  public ResponseEntity<ApiResponseWrapper<?>> getToken(
+      @RequestParam("userId") String userId,
+      @RequestParam(value = "expirationTime", required = false) Long expirationTime) {
+
+    String jwtToken;
+    if (expirationTime != null) {
+      jwtToken = jwtProvider.createJwtToken(userId, expirationTime);
+    } else {
+      jwtToken = jwtProvider.createJwtToken(userId);
+    }
+
+    ApiResponseWrapper<?> response = new ApiResponseWrapper<>(12341243, "토큰 획득", jwtToken);
     return ResponseEntity.ok(response);
   }
 }

--- a/src/main/java/org/bob/siungongsi/api/controller/DevSupportController.java
+++ b/src/main/java/org/bob/siungongsi/api/controller/DevSupportController.java
@@ -1,0 +1,43 @@
+package org.bob.siungongsi.api.controller;
+
+import org.bob.siungongsi.api.controller.spec.DevSupportControllerSpec;
+import org.bob.siungongsi.api.service.UserService;
+import org.bob.siungongsi.common.dto.ApiResponseWrapper;
+import org.bob.siungongsi.common.security.JwtProvider;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Profile({"dev", "local"})
+@RestController
+@RequestMapping("/support")
+public class DevSupportController implements DevSupportControllerSpec {
+
+  private final UserService userService;
+  private final JwtProvider jwtProvider;
+
+  public DevSupportController(UserService userService, JwtProvider jwtProvider) {
+    this.userService = userService;
+    this.jwtProvider = jwtProvider;
+  }
+
+  @GetMapping("/user")
+  @Override
+  public ResponseEntity<ApiResponseWrapper<?>> getUser() {
+    ApiResponseWrapper<?> response =
+        new ApiResponseWrapper<>(12341243, "토큰 획득용 유저 정보", userService.getUser());
+    return ResponseEntity.ok(response);
+  }
+
+  @PostMapping("/token")
+  @Override
+  public ResponseEntity<ApiResponseWrapper<?>> getToken(@RequestParam("userId") String userId) {
+    ApiResponseWrapper<?> response =
+        new ApiResponseWrapper<>(12341243, "토큰 획득", jwtProvider.createJwtToken(userId));
+    return ResponseEntity.ok(response);
+  }
+}

--- a/src/main/java/org/bob/siungongsi/api/controller/spec/DevSupportControllerSpec.java
+++ b/src/main/java/org/bob/siungongsi/api/controller/spec/DevSupportControllerSpec.java
@@ -1,0 +1,18 @@
+package org.bob.siungongsi.api.controller.spec;
+
+import org.bob.siungongsi.common.dto.ApiResponseWrapper;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "개발 및 로컬 환경 편의 API", description = "개발 및 로컬 환경에서 유용한 기능을 제공하는 API")
+public interface DevSupportControllerSpec {
+
+  @Operation(summary = "유저 정보 조회")
+  ResponseEntity<ApiResponseWrapper<?>> getUser();
+
+  @Operation(summary = "토큰 발급")
+  public ResponseEntity<ApiResponseWrapper<?>> getToken(@RequestParam("userId") String userId);
+}

--- a/src/main/java/org/bob/siungongsi/api/controller/spec/DevSupportControllerSpec.java
+++ b/src/main/java/org/bob/siungongsi/api/controller/spec/DevSupportControllerSpec.java
@@ -14,5 +14,7 @@ public interface DevSupportControllerSpec {
   ResponseEntity<ApiResponseWrapper<?>> getUser();
 
   @Operation(summary = "토큰 발급")
-  public ResponseEntity<ApiResponseWrapper<?>> getToken(@RequestParam("userId") String userId);
+  ResponseEntity<ApiResponseWrapper<?>> getToken(
+      @RequestParam("userId") String userId,
+      @RequestParam(value = "expirationTime", required = false) Long expirationTime);
 }

--- a/src/main/java/org/bob/siungongsi/batch/controller/BatchSupportController.java
+++ b/src/main/java/org/bob/siungongsi/batch/controller/BatchSupportController.java
@@ -2,17 +2,12 @@ package org.bob.siungongsi.batch.controller;
 
 import java.util.List;
 
-import org.bob.siungongsi.api.service.UserService;
-import org.bob.siungongsi.batch.controller.spec.AdminControllerSpec;
+import org.bob.siungongsi.batch.controller.spec.BatchSupportControllerSpec;
 import org.bob.siungongsi.batch.service.CompanyNameAutofillGenerator;
 import org.bob.siungongsi.batch.service.ProcessingFailedGongsiService;
 import org.bob.siungongsi.batch.service.TodayProcessedGongsiService;
-import org.bob.siungongsi.common.dto.ApiResponseWrapper;
-import org.bob.siungongsi.common.security.JwtProvider;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -21,28 +16,22 @@ import org.springframework.web.bind.annotation.RestController;
 
 @Profile("batch")
 @RestController
-@RequestMapping("/admin")
-public class AdminController implements AdminControllerSpec {
+@RequestMapping("/support")
+public class BatchSupportController implements BatchSupportControllerSpec {
   @Value("${admin.key}")
   private String adminKey;
 
   private final TodayProcessedGongsiService todayProcessedGongsiService;
   private final ProcessingFailedGongsiService processingFailedGongsiService;
   private final CompanyNameAutofillGenerator companyNameAutofillGenerator;
-  private final UserService userService;
-  private final JwtProvider jwtProvider;
 
-  public AdminController(
+  public BatchSupportController(
       TodayProcessedGongsiService todayProcessedGongsiService,
       ProcessingFailedGongsiService processingFailedGongsiService,
-      CompanyNameAutofillGenerator companyNameAutofillGenerator,
-      UserService userService,
-      JwtProvider jwtProvider) {
+      CompanyNameAutofillGenerator companyNameAutofillGenerator) {
     this.todayProcessedGongsiService = todayProcessedGongsiService;
     this.processingFailedGongsiService = processingFailedGongsiService;
     this.companyNameAutofillGenerator = companyNameAutofillGenerator;
-    this.userService = userService;
-    this.jwtProvider = jwtProvider;
   }
 
   @PostMapping("/remove-processed-gongsi")
@@ -75,21 +64,5 @@ public class AdminController implements AdminControllerSpec {
       throw new RuntimeException("Invalid admin key");
     }
     companyNameAutofillGenerator.generate(startDt, endDt);
-  }
-
-  @GetMapping("/user")
-  @Override
-  public ResponseEntity<ApiResponseWrapper<?>> getUser() {
-    ApiResponseWrapper<?> response =
-        new ApiResponseWrapper<>(12341243, "토큰 획득용 유저 정보", userService.getUser());
-    return ResponseEntity.ok(response);
-  }
-
-  @PostMapping("/token")
-  @Override
-  public ResponseEntity<ApiResponseWrapper<?>> getToken(@RequestParam("userId") String userId) {
-    ApiResponseWrapper<?> response =
-        new ApiResponseWrapper<>(12341243, "토큰 획득", jwtProvider.createJwtToken(userId));
-    return ResponseEntity.ok(response);
   }
 }

--- a/src/main/java/org/bob/siungongsi/batch/controller/spec/BatchSupportControllerSpec.java
+++ b/src/main/java/org/bob/siungongsi/batch/controller/spec/BatchSupportControllerSpec.java
@@ -2,15 +2,11 @@ package org.bob.siungongsi.batch.controller.spec;
 
 import java.util.List;
 
-import org.bob.siungongsi.common.dto.ApiResponseWrapper;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.RequestParam;
-
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
-@Tag(name = "관리자 API", description = "관리를 위한 API")
-public interface AdminControllerSpec {
+@Tag(name = "배치 환경 편의 API", description = "배치 환경에서 유용한 기능을 제공하는 API")
+public interface BatchSupportControllerSpec {
 
   @Operation(summary = "처리된 공시 삭제")
   void removeProcessedGongsiList(String apiKey, List<String> gongsiCodes);
@@ -20,10 +16,4 @@ public interface AdminControllerSpec {
 
   @Operation(summary = "회사명 자동완성")
   void autofillCompanyName(String apiKey, String startDt, String endDt);
-
-  @Operation(summary = "유저 정보 조회")
-  ResponseEntity<ApiResponseWrapper<?>> getUser();
-
-  @Operation(summary = "토큰 발급")
-  public ResponseEntity<ApiResponseWrapper<?>> getToken(@RequestParam("userId") String userId);
 }

--- a/src/main/java/org/bob/siungongsi/common/security/JwtAuthFilter.java
+++ b/src/main/java/org/bob/siungongsi/common/security/JwtAuthFilter.java
@@ -59,7 +59,7 @@ public class JwtAuthFilter extends OncePerRequestFilter {
         || uri.equals("/health")
         || uri.equals("/")
         || uri.matches("/swagger-ui.*")
-        || uri.matches("/admin.*")
+        || uri.matches("/support.*")
         || uri.matches("/v1/companies.*")
         || uri.matches("/v3/api-docs.*")
         || uri.matches("/swagger-resources.*");

--- a/src/main/java/org/bob/siungongsi/common/security/JwtProvider.java
+++ b/src/main/java/org/bob/siungongsi/common/security/JwtProvider.java
@@ -42,6 +42,10 @@ public class JwtProvider {
   }
 
   public String createJwtToken(String userId) {
+    return createJwtToken(userId, expirationTime);
+  }
+
+  public String createJwtToken(String userId, long expirationTime) {
     return Jwts.builder()
         .subject(userId)
         .issuedAt(new Date())


### PR DESCRIPTION
### Description

<!--
  간단하게 PR의 목적을 설명하세요.
  이 PR이 해결하려는 문제나 추가하려는 기능에 대해 요약해주세요.
-->

기존엔 batch 환경에서 `처리 실패 건을 재요청` 하거나 개발 시 사용할 임시 토큰을 만들 수 있었는데
임시 토큰 같은 경우 local, dev 환경에 적합해보여 기존 API 를 분리합니다.
이름도 AdminController 에서 SupportController 로 분리합니다.

### Related Issues

<!--
  관련된 이슈 번호를 참고하세요.
  예: Fixes #123, Closes #456
-->
- Resolves #[이슈 번호]

### Changes Made

<!--
  이 PR에서 변경된 사항을 설명하세요.
  코드, 문서, 설정 등 변경된 내용을 상세히 기술합니다.
-->

1. 기존 AdminController 분리 (BatchSupportController , DevSupportController )
2. createJwtToken 에서 만료시간을 외부에서 주입 받을 수 있게 오버로드 메소드 추가 (유연성 증가)
3. 인증 필터에서 support api 는 인증이 필요없도록 제외

### Screenshots or Video

<!--
  변경된 사항이 UI에 영향을 미치는 경우, 변경 전후의 스크린샷이나 동영상을 첨부하세요.
-->

### Testing

<!--
  변경 사항을 테스트한 방법을 설명하세요.
  테스트한 환경 (OS, 브라우저, 장치 등)과 테스트 절차를 구체적으로 기술합니다.
-->

1. local, dev, prod 로 서버롤 구동시켜 스웨거에서 알맞은 API 가 노출되는지 보고 API 실험함

### Checklist

<!--
  PR 작성 시 다음 항목들을 확인하세요.
-->

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 모든 테스트가 성공적으로 통과했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [x] 코드 스타일 가이드라인을 준수했습니다.
- [x] 코드 리뷰어를 지정했습니다.

### Additional Notes

<!--
  리뷰어가 이해하는 데 도움이 될 추가적인 참고 사항이나 정보가 있다면 여기에 작성하세요.
-->

