### PR TITLE
개발환경 swagger 에서 직접 지정한 URL 로 요청하도록 변경

### DIFF
--- a/src/main/java/org/bob/siungongsi/common/config/ApiDocsConfig.java
+++ b/src/main/java/org/bob/siungongsi/common/config/ApiDocsConfig.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.springdoc.core.customizers.OperationCustomizer;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -13,16 +14,29 @@ import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.parameters.Parameter;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
 
 @Configuration
 public class ApiDocsConfig {
 
+  // dev 환경이 https 프로토콜을 사용하게 되며 직접 https 로 URL 을 설정하기 위해 추가했습니다.
+  // 프록시로 정보를 다룰 수도 있지만 당장 인프라 쪽을 손보기가 까다로워 애플리케이션 코드쪽에 작업을 했습니다.
+  @Value("${swagger.server-url:}")
+  private String swaggerServerUrl;
+
   @Bean
   public OpenAPI openAPI() {
-    return new OpenAPI()
-        .info(createApiInfo())
-        .components(createSecurityComponents())
-        .addSecurityItem(createSecurityRequirement());
+    OpenAPI openAPI =
+        new OpenAPI()
+            .info(createApiInfo())
+            .components(createSecurityComponents())
+            .addSecurityItem(createSecurityRequirement());
+
+    if (swaggerServerUrl != null && !swaggerServerUrl.isEmpty()) {
+      openAPI.addServersItem(new Server().url(swaggerServerUrl));
+    }
+
+    return openAPI;
   }
 
   // API 문서 정보

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -37,6 +37,9 @@ doc:
     enabled: true
     path: /v3/api-docs
 
+swagger:
+  server-url: ${DEV_API_SERVER_URL}
+
 korean:
   investment:
     appkey: ${KOREAN_INVESTMENT_APPKEY}


### PR DESCRIPTION
### Description

dev 환경이 https 도메인을 가지게 되었는데 (nginx 적용 중) 스웨거에서 api 호출 시
http 로 보내고 있습니다. 그래서 https, http 혼합요청 문제로 요청이 거부 당해 이를 해결하는 PR 입니다.
nginx 프록시에서 커스텀 헤더로 스프링 서버에 https 정보를 넘겨줄 수 있는데 인프라 담당자가 다른 일로 바빠
서버 어플리케이션 코드 수준에서 해결했습니다. (직접 서버 URL 지정)

<!--
  간단하게 PR의 목적을 설명하세요.
  이 PR이 해결하려는 문제나 추가하려는 기능에 대해 요약해주세요.
-->


### Related Issues

<!--
  관련된 이슈 번호를 참고하세요.
  예: Fixes #123, Closes #456
-->
- Resolves #195 

### Changes Made

<!--
  이 PR에서 변경된 사항을 설명하세요.
  코드, 문서, 설정 등 변경된 내용을 상세히 기술합니다.
-->

1. application-dev.yml 에 url 지정
2. swagger 설정에 반영
3. dev server url 환경변수 추가

### Screenshots or Video

<!--
  변경된 사항이 UI에 영향을 미치는 경우, 변경 전후의 스크린샷이나 동영상을 첨부하세요.
-->

### Testing

<!--
  변경 사항을 테스트한 방법을 설명하세요.
  테스트한 환경 (OS, 브라우저, 장치 등)과 테스트 절차를 구체적으로 기술합니다.
-->

1. 스웨거 요청 URL 에서 의도대로 동작함 확인 (지정한 URL 로 요청함, dev 환경 외엔 기존 방식대로 동작)

### Checklist

<!--
  PR 작성 시 다음 항목들을 확인하세요.
-->

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 모든 테스트가 성공적으로 통과했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [x] 코드 스타일 가이드라인을 준수했습니다.
- [x] 코드 리뷰어를 지정했습니다.

### Additional Notes

<!--
  리뷰어가 이해하는 데 도움이 될 추가적인 참고 사항이나 정보가 있다면 여기에 작성하세요.
-->

