### PR TITLE
ThridParty API 에 로깅 추가

### DIFF
--- a/src/main/java/org/bob/siungongsi/api/client/clientinterface/KoreanInvestmentClient.java
+++ b/src/main/java/org/bob/siungongsi/api/client/clientinterface/KoreanInvestmentClient.java
@@ -25,7 +25,7 @@ import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 @Component
 public class KoreanInvestmentClient {
 
-  private final Logger logger = LoggerFactory.getLogger(KoreanInvestmentClient.class);
+  private static final Logger logger = LoggerFactory.getLogger(KoreanInvestmentClient.class);
 
   private final ObjectMapper objectMapper;
   private final RestTemplate restTemplate;
@@ -55,13 +55,13 @@ public class KoreanInvestmentClient {
       String accessToken = tokenManager.getAccessToken(ApiKeyStoreManager.KI_API_KEY_NAME);
       return fetchStockData(accessToken, stockCode);
     } catch (Exception e) {
-      logger.error("Error fetching prdyCtr from Korean Investment API: {}", e.getMessage());
+      logger.warn("Error fetching prdyCtr from Korean Investment API: {}", e.getMessage());
       throw new RuntimeException("Failed to fetch prdyCtr: " + e.getMessage());
     }
   }
 
   public double fallbackGetPrdyCtr(String stockCode, Throwable t) {
-    logger.error("Fallback method called for getPrdyCtr: {}", t.getMessage());
+    logger.warn("Fallback method called for getPrdyCtr: {}", t.getMessage());
     return -101;
   }
 

--- a/src/main/java/org/bob/siungongsi/api/service/GongsiService.java
+++ b/src/main/java/org/bob/siungongsi/api/service/GongsiService.java
@@ -33,7 +33,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class GongsiService {
 
-  private final Logger logger = LoggerFactory.getLogger(GongsiService.class);
+  private static final Logger logger = LoggerFactory.getLogger(GongsiService.class);
 
   private final GongsiRepository gongsiRepository;
   private final CompanyRepository companyRepository;
@@ -227,7 +227,7 @@ public class GongsiService {
         prdyCtr = koreanInvestmentClient.getPrdyCtr(stockCode);
       }
     } catch (Exception e) {
-      logger.error("Error fetching prdyCtr: {}", e.getMessage());
+      logger.warn("Error fetching prdyCtr: {}", e.getMessage());
       prdyCtr = 0.0; // Default value
     }
 

--- a/src/main/java/org/bob/siungongsi/batch/ThirdPartyApiLoggingAspect.java
+++ b/src/main/java/org/bob/siungongsi/batch/ThirdPartyApiLoggingAspect.java
@@ -55,7 +55,7 @@ public class ThirdPartyApiLoggingAspect {
             arg -> {
               if (arg == null) return "null";
               String str = arg.toString();
-              return str.length() > 300 ? str.substring(0, 300) + "...)" : str;
+              return str.length() > 300 ? str.substring(0, 300) + "..." : str;
             })
         .collect(Collectors.joining(", ", "[", "]"));
   }

--- a/src/main/java/org/bob/siungongsi/batch/ThirdPartyApiLoggingAspect.java
+++ b/src/main/java/org/bob/siungongsi/batch/ThirdPartyApiLoggingAspect.java
@@ -1,0 +1,62 @@
+package org.bob.siungongsi.batch;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+@Profile("batch")
+public class ThirdPartyApiLoggingAspect {
+
+  private static final Logger logger = LoggerFactory.getLogger(ThirdPartyApiLoggingAspect.class);
+
+  @Around("execution(* org.bob.siungongsi.batch.client.clientinterface.*Wrapper.*(..))")
+  public Object logAroundThirdPartyApi(ProceedingJoinPoint joinPoint) throws Throwable {
+    String className = joinPoint.getTarget().getClass().getSimpleName();
+    String methodName = joinPoint.getSignature().getName();
+    Object[] args = joinPoint.getArgs();
+    String argsString = summarizeArgs(args);
+
+    long start = System.currentTimeMillis();
+    try {
+      logger.info("[{} Call Started] method={}, args={}", className, methodName, argsString);
+      Object result = joinPoint.proceed();
+      long duration = System.currentTimeMillis() - start;
+      logger.info("[{} Call Completed] method={}, duration={}ms", className, methodName, duration);
+      return result;
+    } catch (Exception ex) {
+      long duration = System.currentTimeMillis() - start;
+      logger.warn(
+          "[{} Call Failed] method={}, duration={}ms, exception={}",
+          className,
+          methodName,
+          duration,
+          ex.getMessage(),
+          ex);
+      throw ex;
+    }
+  }
+
+  private String summarizeArgs(Object[] args) {
+    if (args == null || args.length == 0) {
+      return "[]";
+    }
+
+    return Arrays.stream(args)
+        .map(
+            arg -> {
+              if (arg == null) return "null";
+              String str = arg.toString();
+              return str.length() > 300 ? str.substring(0, 300) + "...)" : str;
+            })
+        .collect(Collectors.joining(", ", "[", "]"));
+  }
+}

--- a/src/main/java/org/bob/siungongsi/batch/client/clientinterface/GoogleAiClientWrapper.java
+++ b/src/main/java/org/bob/siungongsi/batch/client/clientinterface/GoogleAiClientWrapper.java
@@ -1,0 +1,27 @@
+package org.bob.siungongsi.batch.client.clientinterface;
+
+import org.bob.siungongsi.batch.client.dto.GoogleAiDtos;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+// GoogleAiClientInterface 는 Spring WebClient 기반 인터페이스 선언형 클라이언트로
+// AOP 가 프록시 객체에 적용되어 명확하게 로깅되지 않는 문제가 있습니다. 따라서 Wrapper 클래스를 생성하여 AOP 를 적용합니다.
+@Profile("batch")
+@Component
+public class GoogleAiClientWrapper {
+  private final GoogleAiClientInterface delegate;
+
+  public GoogleAiClientWrapper(GoogleAiClientInterface googleAiClientInterface) {
+    this.delegate = googleAiClientInterface;
+  }
+
+  public GoogleAiDtos.GoogleAiResponse summarizeWithGemini2Flash(
+      GoogleAiDtos.GoogleAiRequest documentContent) {
+    return delegate.summarizeWithGemini2Flash(documentContent);
+  }
+
+  public GoogleAiDtos.GoogleAiResponse summarizeWithGemini2FlashLite(
+      GoogleAiDtos.GoogleAiRequest documentContent) {
+    return delegate.summarizeWithGemini2FlashLite(documentContent);
+  }
+}

--- a/src/main/java/org/bob/siungongsi/batch/client/clientinterface/OpenDartClientWrapper.java
+++ b/src/main/java/org/bob/siungongsi/batch/client/clientinterface/OpenDartClientWrapper.java
@@ -1,0 +1,26 @@
+package org.bob.siungongsi.batch.client.clientinterface;
+
+import org.bob.siungongsi.batch.client.dto.OpenDartDtos.GongsiListResponse;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+// OpenDartClientInterface 는 Spring WebClient 기반 인터페이스 선언형 클라이언트로
+// AOP 가 프록시 객체에 적용되어 명확하게 로깅되지 않는 문제가 있습니다. 따라서 Wrapper 클래스를 생성하여 AOP 를 적용합니다.
+@Profile("batch")
+@Component
+public class OpenDartClientWrapper {
+
+  private final OpenDartClientInterface delegate;
+
+  public OpenDartClientWrapper(OpenDartClientInterface openDartClientInterface) {
+    this.delegate = openDartClientInterface;
+  }
+
+  public GongsiListResponse getOpenDartList(String bgnDe, String endDe, int pageNo, int pageCount) {
+    return delegate.getOpenDartList(bgnDe, endDe, pageNo, pageCount);
+  }
+
+  public byte[] getOpenDartDocument(String rceptNo) {
+    return delegate.getOpenDartDocument(rceptNo);
+  }
+}

--- a/src/main/java/org/bob/siungongsi/batch/scheduler/PushNotiWorker.java
+++ b/src/main/java/org/bob/siungongsi/batch/scheduler/PushNotiWorker.java
@@ -6,6 +6,8 @@ import org.bob.siungongsi.batch.service.PushNotiService;
 import org.bob.siungongsi.common.domain.GongsiSentStatusEntity;
 import org.bob.siungongsi.common.domain.PushStatus;
 import org.bob.siungongsi.common.repository.GongsiSentStatusRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Profile;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -15,6 +17,8 @@ import org.springframework.stereotype.Component;
 @Profile("batch")
 @Component
 public class PushNotiWorker {
+
+  private static final Logger logger = LoggerFactory.getLogger(PushNotiWorker.class);
 
   private final GongsiSentStatusRepository gongsiSentStatusRepository;
   private final PushNotiService pushNotiService;
@@ -29,24 +33,40 @@ public class PushNotiWorker {
   // @Transactional 외부 API에 의존하기에 한 건씩 개별적으로 처리합니다.
   @Scheduled(fixedDelay = 10000) // 10초마다 실행
   public void processPendingPushes() {
+    logger.info("Push task started");
+
     Pageable pageable = PageRequest.of(0, 50);
     List<GongsiSentStatusEntity> pendingNotices =
         gongsiSentStatusRepository.findByStatus(PushStatus.PENDING, pageable);
 
     for (GongsiSentStatusEntity sentStatus : pendingNotices) {
-      boolean success = pushNotiService.sendPushNotification(sentStatus.getGongsi());
+      try {
+        boolean success = pushNotiService.sendPushNotification(sentStatus.getGongsi());
 
-      if (success) {
-        sentStatus.markAsSent();
-      } else {
-        if (sentStatus.getRetryCount() < MAX_RETRIES) {
-          sentStatus.incrementRetryCount();
+        if (success) {
+          sentStatus.markAsSent();
         } else {
-          sentStatus.markAsFailed();
+          if (sentStatus.getRetryCount() < MAX_RETRIES) {
+            sentStatus.incrementRetryCount();
+            logger.info(
+                "Push notification failed for receiptNo={}, retryCount={}",
+                sentStatus.getGongsi().getGongsiCode(),
+                sentStatus.getRetryCount());
+          } else {
+            sentStatus.markAsFailed();
+            logger.warn(
+                "Push notification failed for receiptNo={}, maxRetryCount reached",
+                sentStatus.getGongsi().getGongsiCode());
+          }
         }
+      } catch (Exception e) {
+        logger.warn(
+            "receiptNo={}, error={}", sentStatus.getGongsi().getGongsiCode(), e.getMessage(), e);
+        sentStatus.incrementRetryCount();
       }
 
       gongsiSentStatusRepository.save(sentStatus);
     }
+    logger.info("Push task finished: processedCount={}", pendingNotices.size());
   }
 }

--- a/src/main/java/org/bob/siungongsi/batch/service/FcmService.java
+++ b/src/main/java/org/bob/siungongsi/batch/service/FcmService.java
@@ -8,6 +8,8 @@ import java.util.Map;
 
 import org.bob.siungongsi.common.dto.ApiResponseCode;
 import org.bob.siungongsi.common.exception.CustomException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
@@ -19,12 +21,13 @@ import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.Message;
 import com.google.firebase.messaging.Notification;
 
-import io.sentry.Sentry;
 import jakarta.annotation.PostConstruct;
 
 @Profile("batch")
 @Service
 public class FcmService {
+
+  private final Logger logger = LoggerFactory.getLogger(FcmService.class);
 
   @Value("${fcm.key}")
   private String firebaseJsonBase64;
@@ -74,8 +77,9 @@ public class FcmService {
 
     try {
       firebaseMessaging.send(message);
+      logger.info("Push notification sent to token: {}", token);
     } catch (Exception e) {
-      Sentry.captureException(e);
+      logger.error("Failed to send push notification: {}", e.getMessage());
     }
   }
 }

--- a/src/main/java/org/bob/siungongsi/batch/service/GongsiSummarizer.java
+++ b/src/main/java/org/bob/siungongsi/batch/service/GongsiSummarizer.java
@@ -2,7 +2,7 @@ package org.bob.siungongsi.batch.service;
 
 import static org.bob.siungongsi.batch.util.TextUtil.removeMarkdown;
 
-import org.bob.siungongsi.batch.client.clientinterface.GoogleAiClientInterface;
+import org.bob.siungongsi.batch.client.clientinterface.GoogleAiClientWrapper;
 import org.bob.siungongsi.batch.client.dto.GoogleAiDtos.GoogleAiRequest;
 import org.bob.siungongsi.batch.client.dto.GoogleAiDtos.GoogleAiResponse;
 import org.bob.siungongsi.common.client.RetryClientHttpRequestInterceptor.RetriesExceededException;
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Service;
 @Service
 public class GongsiSummarizer {
 
-  private final GoogleAiClientInterface googleAiClientInterface;
+  private final GoogleAiClientWrapper googleAiClient;
 
   private static final String DEFAULT_SUMMARY_PROMPT =
       "다음 문서를 요약해 주세요.\n"
@@ -25,8 +25,8 @@ public class GongsiSummarizer {
           + "항목 구분은 기호 없이 문장으로 표현하고, 제목은 따로 표시하지 마세요.\n"
           + "각 항목은 새로운 줄에서 시작해야 합니다.\n";
 
-  public GongsiSummarizer(GoogleAiClientInterface googleAiClientInterface) {
-    this.googleAiClientInterface = googleAiClientInterface;
+  public GongsiSummarizer(GoogleAiClientWrapper googleAiClient) {
+    this.googleAiClient = googleAiClient;
   }
 
   public String summarizeText(String text, String prompt) {
@@ -35,13 +35,12 @@ public class GongsiSummarizer {
 
     try {
       // 🔥 1. 기본 모델 (`gemini-2.0-flash`) 요청
-      GoogleAiResponse response = googleAiClientInterface.summarizeWithGemini2Flash(request);
+      GoogleAiResponse response = googleAiClient.summarizeWithGemini2Flash(request);
       return removeMarkdown(response.getSummary());
     } catch (RetriesExceededException e) {
       try {
         // 🔥 2. 대체 모델 (`gemini-2.0-flash-lite`) 요청
-        GoogleAiResponse fallbackResponse =
-            googleAiClientInterface.summarizeWithGemini2FlashLite(request);
+        GoogleAiResponse fallbackResponse = googleAiClient.summarizeWithGemini2FlashLite(request);
         return removeMarkdown(fallbackResponse.getSummary());
       } catch (RetriesExceededException ex) {
         throw new RuntimeException("모든 모델 요청 실패", ex);

--- a/src/main/java/org/bob/siungongsi/batch/service/OpenDartReader.java
+++ b/src/main/java/org/bob/siungongsi/batch/service/OpenDartReader.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.bob.siungongsi.api.service.RankedCompanyManager;
 import org.bob.siungongsi.batch.client.clientinterface.OpenDartClientWrapper;
 import org.bob.siungongsi.batch.client.dto.OpenDartDtos.GongsiData;
 import org.bob.siungongsi.batch.client.dto.OpenDartDtos.GongsiListResponse;

--- a/src/main/java/org/bob/siungongsi/batch/service/OpenDartReader.java
+++ b/src/main/java/org/bob/siungongsi/batch/service/OpenDartReader.java
@@ -4,8 +4,7 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.bob.siungongsi.api.service.RankedCompanyManager;
-import org.bob.siungongsi.batch.client.clientinterface.OpenDartClientInterface;
+import org.bob.siungongsi.batch.client.clientinterface.OpenDartClientWrapper;
 import org.bob.siungongsi.batch.client.dto.OpenDartDtos.GongsiData;
 import org.bob.siungongsi.batch.client.dto.OpenDartDtos.GongsiListResponse;
 import org.springframework.context.annotation.Profile;
@@ -15,12 +14,12 @@ import org.springframework.stereotype.Component;
 @Component
 public class OpenDartReader {
   private static final int PAGE_SIZE = 100;
-  private final OpenDartClientInterface openDartClient;
+  private final OpenDartClientWrapper openDartClient;
   private final TodayProcessedGongsiManager todayProcessedGongsiManager;
   private final RankedCompanyManager rankedCompanyManager;
 
   public OpenDartReader(
-      OpenDartClientInterface openDartClient,
+      OpenDartClientWrapper openDartClient,
       TodayProcessedGongsiManager todayProcessedGongsiManager,
       RankedCompanyManager rankedCompanyManager) {
     this.openDartClient = openDartClient;

--- a/src/main/java/org/bob/siungongsi/batch/service/PushNotiService.java
+++ b/src/main/java/org/bob/siungongsi/batch/service/PushNotiService.java
@@ -9,6 +9,8 @@ import org.bob.siungongsi.common.domain.UserEntity;
 import org.bob.siungongsi.common.repository.CompanyRepository;
 import org.bob.siungongsi.common.repository.NotificationRepository;
 import org.bob.siungongsi.common.repository.UserRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
@@ -17,6 +19,7 @@ import org.springframework.stereotype.Service;
 @Service
 public class PushNotiService {
 
+  private static final Logger logger = LoggerFactory.getLogger(PushNotiService.class);
   private final FcmService fcmService;
   private final NotificationRepository notificationRepository;
   private final UserRepository userRepository;
@@ -46,6 +49,14 @@ public class PushNotiService {
       if (user.getPushTokenId() == null || user.getPushTokenId().isBlank()) {
         continue;
       }
+
+      logger.info(
+          "Sending push notification to userId={}, token={} , gongsiId={} , companyId={}",
+          user.getId(),
+          user.getPushTokenId(),
+          gongsi.getId(),
+          gongsi.getCompany().getId());
+
       if (!sendMessage(user.getPushTokenId(), gongsi)) {
         return false;
       }


### PR DESCRIPTION
### Description

<!--
  간단하게 PR의 목적을 설명하세요.
  이 PR이 해결하려는 문제나 추가하려는 기능에 대해 요약해주세요.
-->

외부 API 호출 여부, 응답시간 등을 관리하기 위해 로깅을 추가합니다.
외부 API 호출이 잦은만큼 로그가 많이 쌓일 것 같은데 주의가 필요해보입니다.

### Related Issues

<!--
  관련된 이슈 번호를 참고하세요.
  예: Fixes #123, Closes #456
-->
- Resolves #[이슈 번호]

### Changes Made

<!--
  이 PR에서 변경된 사항을 설명하세요.
  코드, 문서, 설정 등 변경된 내용을 상세히 기술합니다.
-->

1. 푸시 알림 로깅 적용
2. 한투 API 로깅 적용
3. OpenDart, GoogleAi wrapper 클래스 작성
4. wrapper 클래스 대상 로깅 aop 작성
5. 기존 로깅들 로깅레벨 수정 (어느 정도 실패를 감수해야하는 외부 API 들은 error -> warn 으로 변경)

### Screenshots or Video

<!--
  변경된 사항이 UI에 영향을 미치는 경우, 변경 전후의 스크린샷이나 동영상을 첨부하세요.
-->

### Testing

<!--
  변경 사항을 테스트한 방법을 설명하세요.
  테스트한 환경 (OS, 브라우저, 장치 등)과 테스트 절차를 구체적으로 기술합니다.
-->

1. 실제 서버를 돌려 로깅을 했습니다.

### Checklist

<!--
  PR 작성 시 다음 항목들을 확인하세요.
-->

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 모든 테스트가 성공적으로 통과했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [x] 코드 스타일 가이드라인을 준수했습니다.
- [x] 코드 리뷰어를 지정했습니다.

### Additional Notes

<!--
  리뷰어가 이해하는 데 도움이 될 추가적인 참고 사항이나 정보가 있다면 여기에 작성하세요.
-->

사용하는 외부 API 들이 처리율 제한 등으로 인해 실패할 확률이 어느 정도 높습니다.
이러한 부분은 retry 정책을 통해 처리하고 있고 어느 정도 실패를 감수하기에 로깅 레벨을
error -> warn 으로 낮춥니다.