### PR TITLE
feat: 주가 캐싱

### DIFF
--- a/src/main/java/org/bob/siungongsi/api/client/clientinterface/KoreanInvestmentClient.java
+++ b/src/main/java/org/bob/siungongsi/api/client/clientinterface/KoreanInvestmentClient.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.bob.siungongsi.api.service.ApiKeyStoreManager;
+import org.bob.siungongsi.api.service.StockCacheService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -30,6 +31,7 @@ public class KoreanInvestmentClient {
   private final ObjectMapper objectMapper;
   private final RestTemplate restTemplate;
   private final ApiKeyStoreManager tokenManager;
+  private final StockCacheService stockCacheService;
 
   @Value("${korean.investment.appkey}")
   private String appKey;
@@ -43,9 +45,13 @@ public class KoreanInvestmentClient {
   @Value("${korean.investment.token.url}")
   private String tokenUrl;
 
-  public KoreanInvestmentClient(ObjectMapper objectMapper, ApiKeyStoreManager tokenManager) {
+  public KoreanInvestmentClient(
+      ObjectMapper objectMapper,
+      ApiKeyStoreManager tokenManager,
+      StockCacheService stockCacheService) {
     this.objectMapper = objectMapper;
     this.tokenManager = tokenManager;
+    this.stockCacheService = stockCacheService;
     this.restTemplate = new RestTemplate();
   }
 
@@ -62,6 +68,14 @@ public class KoreanInvestmentClient {
 
   public double fallbackGetPrdyCtr(String stockCode, Throwable t) {
     logger.warn("Fallback method called for getPrdyCtr: {}", t.getMessage());
+    if (stockCacheService.hasCachedStock(stockCode)) {
+      Object cachedValue = stockCacheService.getCachedStockPrice(stockCode);
+      if (cachedValue instanceof Double) {
+        return (Double) cachedValue;
+      } else {
+        return -101;
+      }
+    }
     return -101;
   }
 
@@ -89,8 +103,9 @@ public class KoreanInvestmentClient {
       JsonNode root = objectMapper.readTree(responseBody);
       JsonNode outputData = root.path("output");
       String prdyCtrt = outputData.path("prdy_ctrt").asText();
-
-      return Double.parseDouble(prdyCtrt.replaceAll("[^0-9.-]", ""));
+      Double prdyCtr = Double.parseDouble(prdyCtrt.replaceAll("[^0-9.-]", ""));
+      stockCacheService.cacheStockPrice(stockCode, prdyCtr);
+      return prdyCtr;
 
     } catch (RestClientException e) {
       logger.error("Error fetching stock data from Korean Investment API: {}", e.getMessage());

--- a/src/main/java/org/bob/siungongsi/api/client/clientinterface/KoreanInvestmentClient.java
+++ b/src/main/java/org/bob/siungongsi/api/client/clientinterface/KoreanInvestmentClient.java
@@ -57,25 +57,15 @@ public class KoreanInvestmentClient {
 
   @CircuitBreaker(name = "stockPriceService", fallbackMethod = "fallbackGetPrdyCtr")
   public double getPrdyCtr(String stockCode) {
-    try {
-      String accessToken = tokenManager.getAccessToken(ApiKeyStoreManager.KI_API_KEY_NAME);
-      return fetchStockData(accessToken, stockCode);
-    } catch (Exception e) {
-      logger.warn("Error fetching prdyCtr from Korean Investment API: {}", e.getMessage());
-      throw new RuntimeException("Failed to fetch prdyCtr: " + e.getMessage());
+    String accessToken = tokenManager.getAccessToken(ApiKeyStoreManager.KI_API_KEY_NAME);
+    if (stockCacheService.hasCachedStock(stockCode)) {
+      return (double) stockCacheService.getCachedStockPrice(stockCode);
     }
+    return fetchStockData(accessToken, stockCode);
   }
 
   public double fallbackGetPrdyCtr(String stockCode, Throwable t) {
     logger.warn("Fallback method called for getPrdyCtr: {}", t.getMessage());
-    if (stockCacheService.hasCachedStock(stockCode)) {
-      Object cachedValue = stockCacheService.getCachedStockPrice(stockCode);
-      if (cachedValue instanceof Double) {
-        return (Double) cachedValue;
-      } else {
-        return -101;
-      }
-    }
     return -101;
   }
 
@@ -102,11 +92,13 @@ public class KoreanInvestmentClient {
 
       JsonNode root = objectMapper.readTree(responseBody);
       JsonNode outputData = root.path("output");
+
       String prdyCtrt = outputData.path("prdy_ctrt").asText();
       Double prdyCtr = Double.parseDouble(prdyCtrt.replaceAll("[^0-9.-]", ""));
-      stockCacheService.cacheStockPrice(stockCode, prdyCtr);
-      return prdyCtr;
 
+      stockCacheService.cacheStockPrice(stockCode, prdyCtr);
+
+      return prdyCtr;
     } catch (RestClientException e) {
       logger.error("Error fetching stock data from Korean Investment API: {}", e.getMessage());
       throw new RuntimeException("Failed to fetch stock data: " + e.getMessage());

--- a/src/main/java/org/bob/siungongsi/api/service/StockCacheService.java
+++ b/src/main/java/org/bob/siungongsi/api/service/StockCacheService.java
@@ -13,7 +13,7 @@ public class StockCacheService {
   }
 
   public void cacheStockPrice(String stockCode, Double value) {
-    redisUtils.set(PREFIX + stockCode, value, 300000L);
+    redisUtils.set(PREFIX + stockCode, value, 30000L);
   }
 
   public Object getCachedStockPrice(String stockCode) {

--- a/src/main/java/org/bob/siungongsi/api/service/StockCacheService.java
+++ b/src/main/java/org/bob/siungongsi/api/service/StockCacheService.java
@@ -1,0 +1,26 @@
+package org.bob.siungongsi.api.service;
+
+import org.bob.siungongsi.common.util.RedisUtils;
+import org.springframework.stereotype.Service;
+
+@Service
+public class StockCacheService {
+  private final RedisUtils redisUtils;
+  private static final String PREFIX = "stock:";
+
+  public StockCacheService(RedisUtils redisUtils) {
+    this.redisUtils = redisUtils;
+  }
+
+  public void cacheStockPrice(String stockCode, Double value) {
+    redisUtils.set(PREFIX + stockCode, value, 300000L);
+  }
+
+  public Object getCachedStockPrice(String stockCode) {
+    return redisUtils.get(PREFIX + stockCode);
+  }
+
+  public boolean hasCachedStock(String stockCode) {
+    return redisUtils.hasKey(PREFIX + stockCode);
+  }
+}

--- a/src/main/java/org/bob/siungongsi/common/util/RedisUtils.java
+++ b/src/main/java/org/bob/siungongsi/common/util/RedisUtils.java
@@ -18,8 +18,8 @@ public class RedisUtils {
     redisTemplate.opsForValue().set(key, value, expiredTime, TimeUnit.MILLISECONDS);
   }
 
-  public String get(String key) {
-    return (String) redisTemplate.opsForValue().get(key);
+  public Object get(String key) {
+    return redisTemplate.opsForValue().get(key);
   }
 
   public boolean delete(String key) {


### PR DESCRIPTION
### Description

<!--
  간단하게 PR의 목적을 설명하세요.
  이 PR이 해결하려는 문제나 추가하려는 기능에 대해 요약해주세요.
-->

주가 캐싱해서 1초에 2건 초과해서 오류가 날 시 캐싱된 주가정보라도 보여주기 

### Related Issues

<!--
  관련된 이슈 번호를 참고하세요.
  예: Fixes #123, Closes #456
-->
- Resolves #207

### Changes Made

<!--
  이 PR에서 변경된 사항을 설명하세요.
  코드, 문서, 설정 등 변경된 내용을 상세히 기술합니다.
-->

기존 방식
1. 5분 동안의 유효 기간으로 주가 정보 캐싱
2. 단, 에러가 났을 때만 캐싱한 정보 보여줌
3. 캐싱된 주가 정보 없을 시에는 -101반환

변경 방식
1. 30초 동안의 유효 기간으로 주가 정보 캐싱
2. 바로 캐싱된 주가 정보 조회 후 있으면 반환
3. 없으면 한투 api에 요청 
4. 실패시 -101 반환 

5. RedisUtil value type Object로 변경
6. redis key값: stock: 스톡코드


### Screenshots or Video

<!--
  변경된 사항이 UI에 영향을 미치는 경우, 변경 전후의 스크린샷이나 동영상을 첨부하세요.
-->

### Testing

<!--
  변경 사항을 테스트한 방법을 설명하세요.
  테스트한 환경 (OS, 브라우저, 장치 등)과 테스트 절차를 구체적으로 기술합니다.
-->

1. jmeter로 10번 요청을 1초안에 날렸더니 무리 없이 캐싱된 정보 보여줌 

### Checklist

<!--
  PR 작성 시 다음 항목들을 확인하세요.
-->

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 모든 테스트가 성공적으로 통과했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [x] 코드 스타일 가이드라인을 준수했습니다.
- [x] 코드 리뷰어를 지정했습니다.

### Additional Notes

<!--
  리뷰어가 이해하는 데 도움이 될 추가적인 참고 사항이나 정보가 있다면 여기에 작성하세요.
-->
